### PR TITLE
Added UTF-8 settings for Windows

### DIFF
--- a/.emacs
+++ b/.emacs
@@ -1,3 +1,9 @@
+(prefer-coding-system 'utf-8)
+(set-default-coding-systems 'utf-8)
+(set-terminal-coding-system 'utf-8)
+(set-keyboard-coding-system 'utf-8)
+
+
 (load-theme 'tsdh-dark)
 (menu-bar-mode 0)
 (tool-bar-mode 0)


### PR DESCRIPTION
UTF-8 is the default file encoding on Linux, but not on Windows.